### PR TITLE
Add missing scikit-learn dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
 - matplotlib
 - numpy
 - pandas
+- scikit-learn
 - seaborn
 - statsmodels
 - networkx


### PR DESCRIPTION
Thanks for your notebooks!

scikit-learn is needed for Notebook `06-causality-identifiability`, so I've added it to the `environment.yml`.